### PR TITLE
Update Transform.java to remove redundant check of datatype

### DIFF
--- a/src/main/java/de/graetz23/jwave/Transform.java
+++ b/src/main/java/de/graetz23/jwave/Transform.java
@@ -58,8 +58,6 @@ public final class Transform {
         try {
             if (_basicTransform == null)
                 throw new JWaveFailure("given object is null!");
-            if (!(_basicTransform instanceof BasicTransform))
-                throw new JWaveFailure("given object is not of type BasicTransform");
         } catch (JWaveException e) {
             e.showMessage();
             e.printStackTrace();


### PR DESCRIPTION
This PR removes a redundant instanceof check in the Transform constructor. Since the parameter is already typed as BasicTransform, the check will always evaluate to true (except for null, which is already handled).